### PR TITLE
Fixed small bug where the user can not use --trimQ FRAC mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,27 +71,22 @@ if(RSCRIPT_EXEC AND HAVE_PANDOC)
       set(HAVE_RPKG TRUE)
    endif(R_rmarkdown AND R_pheatmap AND R_knitr)
 endif(RSCRIPT_EXEC AND HAVE_PANDOC)
-
 #---------------------------------------------------------------
 # Setting defines. Can be modified with -DVARNAME in the command line 
 #---------------------------------------------------------------
 set(READ_MAXLEN 400 CACHE STRING "Illumina maximum read length")
 message("-- Setting Illumina maximum read length: READ_MAXLEN ${READ_MAXLEN}")
-
-set(RMD_QUALITY_REPORT ${INSTALL_R_DIR}/R/quality_report.Rmd CACHE STRING 
-   "Rmd quality report file")
+message(${INSTALL_R_DIR})
+set(RMD_QUALITY_REPORT ${INSTALL_R_DIR}/R/quality_report.Rmd)
 message("-- Setting Rmd quality report file: ${RMD_QUALITY_REPORT}")
 
-set(RMD_SUMMARY_REPORT ${INSTALL_R_DIR}/R/summary_report.Rmd CACHE STRING 
-   "Rmd summary report file")
+set(RMD_SUMMARY_REPORT ${INSTALL_R_DIR}/R/summary_report.Rmd)
 message("-- Setting Rmd summary report file: ${RMD_SUMMARY_REPORT}")
 
-set(RMD_SUMMARY_FILTER_REPORT ${INSTALL_R_DIR}/R/summary_filter_report.Rmd 
-   CACHE STRING  "Rmd summary filter report file")
+set(RMD_SUMMARY_FILTER_REPORT ${INSTALL_R_DIR}/R/summary_filter_report.Rmd )
 message("-- Setting Rmd summary filter report file: ${RMD_SUMMARY_FILTER_REPORT}")
 
-set(RMD_SUMMARY_FILTER_REPORTDS ${INSTALL_R_DIR}/R/summary_filter_reportDS.Rmd 
-   CACHE STRING  "Rmd summary filter report file for DS data")
+set(RMD_SUMMARY_FILTER_REPORTDS ${INSTALL_R_DIR}/R/summary_filter_reportDS.Rmd )
 message("-- Setting Rmd summary filter report file for DS data: ${RMD_SUMMARY_FILTER_REPORTDS}")
 #MISSING SETTING MEMORY ROOF!!! 
 

--- a/README_trimFilterPE.md
+++ b/README_trimFilterPE.md
@@ -16,53 +16,54 @@ automatically discarded as well.
 Usage `C` executable (in folder `bin`):
 
 ```
-Usage: trimFilterPE --ifq <INPUT1.fq>:<INPUT2.fq> --length <READ_LENGTH>
+Usage: trimFilterPE --ifq <INPUT1.fq>:<INPUT2.fq> --length <READ_LENGTH> 
                   --output [O_PREFIX] --gzip [y|n]
                   --adapter [<AD1.fa>:<AD2.fa>:<mismatches>:<score>]
-                  --method [TREE|BLOOM]
+                  --method [TREE|BLOOM] 
                   (--idx [<INDEX_FILE>:<score>:<lmer_len>] |
                    --ifa [<INPUT.fa>:<score>:[lmer_len]])
                   --trimQ [NO|ALL|ENDS|FRAC|ENDSFRAC|GLOBAL]
-                  --minL [MINL]  --minQ [MINQ] --zeroQ [ZEROQ]
+                  --minL [MINL]  --minQ [MINQ]  --zeroQ [ZEROQ]
                   (--percent [percent] | --global [n1:n2])
-                  --trimN [NO|ALL|ENDS|STRIP]
+                  --trimN [NO|ALL|ENDS|STRIP]  
 Reads in paired end fq files (gz, bz2, z formats also accepted) and removes:
   * low quality reads,
   * reads containing N base callings,
-  * reads representing contaminations, belonging to sequences in INPUT.fa
-Outputs 4 [O_PREFIX]_fq.gz files per input fastq file containing: "good" reads,
-discarded low quality reads, discarded reads containing N's, discarded contaminations.
-
-If one read is removed, the corresponding paired read is removed as well.
-
+  * reads representing contaminations, belonging to sequences in INPUT.fa.
+Outputs 8 [O_PREFIX][1|2]_fq.gz files containing: "good" reads, discarded 
+low Q reads, discarded reads containing N's, discarded contaminations.
 Options:
  -v, --version prints package version.
  -h, --help    prints help dialog.
- -f, --ifq     2 fastq input files [*fq|*fq.gz|*fq.bz2] separated by colons, mandatory option.
+ -f, --ifq     2 fastq input files [*fq|*fq.gz|*fq.bz2] separated by
+               colons, mandatory option.
  -l, --length  read length: length of the reads, mandatory option.
- -o, --output  output prefix (with path), optional (default ./out). 
- -z, --gzip    gzips output files: yes or no (default yes).
+ -o, --output  output prefix (with path), optional (default ./out).
+ -z, --gzip    gzip output files: yes or no (default yes)
  -A, --adapter adapter input. Four fields separated by colons:
-               <AD1.fa>: fasta file containing adapters from read 1,
-               <AD2.fa>: fasta file containing adapters from read 2,
+               <AD1.fa>: fasta file containing adapters,
+               <AD2.fa>: fasta file containing adapters,
                <mismatches>: maximum mismatch count allowed,
                <score>: score threshold  for the aligner.
- -x, --idx     index input file. To be included with any method. 
-               3 fields separated by colons:
-               <INDEX_FILE>: output of makeTree or makeBloom,
+ -r, --adapter-rm  if the adapter is matched, instead of trimming it
+               , the reads are removed. 
+ -x, --idx     index input file. To be included with any methods to remove.
+               contaminations (TREE, BLOOM). 3 fields separated by colons: 
+               <INDEX_FILE>: output of makeTree, makeBloom,
                <score>: score threshold to accept a match [0,1],
-               [lmer_len]: corresponds to the length of the lmers to be
+               [lmer_len]: the length of the lmers to be 
                         looked for in the reads [1,READ_LENGTH].
- -a, --ifa     fasta input file. To be included only with method TREE
+ -a, --ifa     fasta input file of potential contaminations.
+               To be included only with method TREE
                (it excludes the option --idx). Otherwise, an
                index file has to be precomputed and given as parameter
-               (see option --idx). 3 fields separated by colons:
+               (see option --idx). 3 fields separated by colons: 
                <INPUT.fa>: fasta input file [*fa|*fa.gz|*fa.bz2],
                <score>: score threshold to accept a match [0,1],
                <lmer_len>: depth of the tree: [1,READ_LENGTH]. 
-                        corresponds to the length of the lmers to be
+                        Corresponds to the length of the lmers to be 
                         looked for in the reads.
- -C, --method  method used to look for contaminations:
+ -C, --method  method used to look for contaminations: 
                TREE:  uses a 4-ary tree. Index file optional,
                BLOOM: uses a bloom filter. Index file mandatory.
  -Q, --trimQ   NO:       does nothing to low quality reads (default),
@@ -70,29 +71,34 @@ Options:
                          quality nucleotide.
                ENDS:     trims the ends of the read if their quality is
                          below the threshold -q,
-               FRAC:     discards a read if the fraction of bases whose
-                         quality lies below the threshold -q is over 
-			 5 percent or a user defined percentage in -p.
-               ENDSFRAC: trims the ends and then discards the read if
+               FRAC:     discards a read if the fraction of bases with
+                         low quality scores (below -q) is over 5 percent 
+                         or a user defined percentage (-p). 
+               ENDSFRAC: trims the ends and then discards the read if 
                          there are more low quality nucleotides than 
                          allowed by the option -p.
-               GLOBAL:   removes n1 bases on the left and n2 on the
+               GLOBAL:   removes n1 cycles on the left and n2 on the 
                          right, specified in -g.
-               All reads are discarded if they are shorter than minL.
- -m, --minL    minimum length allowed for a read before it is discarded
+               All reads are discarded if they are shorter than MINL
+               (specified with -m or --minL).
+  -m, --minL    minimum length allowed for a read before it is discarded
                (default 25).
  -q, --minQ    minimum quality allowed (int), optional (default 27).
  -0, --zeroQ   value of ASCII character representing zero quality (int), optional (default 33)
- -p, --percent percentage of low quality bases to be admitted before
-               discarding a read (default 5),
+ -p, --percent percentage of low quality bases tolerated before 
+               discarding a read (default 5), 
  -g, --global  required option if --trimQ GLOBAL is passed. Two int,
-               n1:n2, have to be passed specifying the number of bases
+               n1:n2, have to be passed specifying the number of bases 
                to be globally cut from the left and right, respectively.
  -N, --trimN   NO:     does nothing to reads containing N's,
                ALL:    removes all reads containing N's,
                ENDS:   trims ends of reads with N's,
                STRIPS: looks for the largest substring with no N's.
-               All reads are discarded if they are shorter than minL.
+               FRAC:   removes the reads if the uncertainty is above a threshold
+                       (-u), default to 10 percent
+               All reads are discarded if they are shorter than the
+               sequence length specified by -m/--minL.
+ -u, --uncert  percentage of uncertainity tolerated
 ```
 
 NOTE: the parameters -l or --length are meant to identify the length
@@ -131,6 +137,9 @@ hold the length of the longest read in the dataset.
 
 Technical sequences within the reads are detected if the option
 `--adapters <ADAPTERS1.fa>:<ADAPTERS2.fa>:<mismatches>:<score>` is given.
+
+If the option `-r` is provided, the reads that have adapter contamination will be removed instead of trimmed. 
+
 The adapter(s) sequence(s) are read from the fasta files, and then prepended
 to their respective reads. Then, a 'seed and extend' approach is used
 to look for overlaps following the same rules followed in the single end case.
@@ -142,7 +151,6 @@ cases:
 <p align="center">
 <img src=./pics/adapters/palindrome_new.png alt="noimage" title="Adapters identification">
 </p>
-
 
 #### Impurities/biological contamination
 
@@ -190,6 +198,8 @@ examples and more details):
 - `--trimN NO` (or flag absent): Nothing is done to the reads containing N's.
 - `--trimN ALL`: All reads containing at least one N are redirected to
   `*_NNNN.fq.gz`
+- `--trimN FRAC [-u] ` : All reads containing more than the percentage specified by -u (default 10%) are redirected to
+  `*_NNNN.fq.gz`
 - `--trimN ENDS`: N's are trimmed if found at the ends, left "as is"
   otherwise. If the trimmed read length is smaller than minL, it is discarded.
 - `--trimN STRIP`: Obtain the largest N free subsequence of the read. Accept it
@@ -200,6 +210,7 @@ examples and more details):
 
  The examples in folder `examples/trimFilterPE_SReport/` work in the following
  way:
+
  1. See folder `fa_fq_files`. The files `EColi_rRNA_DS.read1.fq.gz` and
     `EColi_rRNA_DS.read2.fq.gz` were created with `create_fq.sh` and contain:
     * 1000 reads of length 50 from `EColi_genome.fa` with NO errors.
@@ -229,7 +240,7 @@ examples and more details):
 
 ## Contributors
 
-Paula Pérez Rubio
+Paula Pérez Rubio, Félix Laguna Teno
 
 ## License
 

--- a/include/struct_trimFilter.h
+++ b/include/struct_trimFilter.h
@@ -74,6 +74,8 @@ typedef struct _iparam_trimFilter {
   int globleft;  /**< number of bases globally trimming from the left */
   int globright; /**< number of bases globally trimming from the right */
   int percent;   /**< percentage of lowQ bases allowed in a read */
+  int uncertain; /**< percentage of N bases allowed in a read */
+  bool adapter_rm; /**< true if the adapter matching sequences should be dropped instead of trimmed */
 } Iparam_trimFilter;
 
 void free_parTF(Iparam_trimFilter *ptr_parTF);

--- a/src/init_trimFilterDS.c
+++ b/src/init_trimFilterDS.c
@@ -506,7 +506,7 @@ void getarg_trimFilterDS(int argc, char **argv) {
       exit(EXIT_FAILURE);
   }
   // Consistenty checks
-  if ((par_TF.trimQ != ENDS) && (par_TF.trimQ != ENDSFRAC) &&
+  if ((par_TF.trimQ != ENDS) && (par_TF.trimQ != ENDSFRAC) && (par_TF.trimQ != FRAC) &&
       (par_TF.percent != 0)) {
       fprintf(stderr, "%d\n", par_TF.percent);
       fprintf(stderr, "OPTION_ERROR: --percent passed as an option, but ");

--- a/src/init_trimFilterDS.c
+++ b/src/init_trimFilterDS.c
@@ -74,7 +74,7 @@ void printHelpDialog_trimFilterDS() {
    "               <mismatches>: maximum mismatch count allowed,\n"
    "               <score>: score threshold  for the aligner.\n"
    " -r, --adapter-rm  if the adapter is matched, instead of trimming it\n"
-   "               , the reads are removed."
+   "               , the reads are removed.\n"
    " -x, --idx     index input file. To be included with any methods to remove.\n"
    "               contaminations (TREE, BLOOM). 3 fields separated by colons: \n"
    "               <INDEX_FILE>: output of makeTree, makeBloom,\n"
@@ -176,7 +176,7 @@ void getarg_trimFilterDS(int argc, char **argv) {
   int option;
   int method_len = 20;
   Split globTrim, adapt, tree_fa, index, in_fq;
-  while ((option = getopt_long(argc, argv, "hvf:l:o:z:A:q:x:a:C:Q:m:p:g:N:0:r:u:",
+  while ((option = getopt_long(argc, argv, "hvf:l:o:z:A:q:x:a:C:Q:m:p:g:N:0:ru:",
         long_options, 0)) != -1) {
     fprintf(stderr,"%c\n",option);
     switch (option) {
@@ -379,6 +379,9 @@ void getarg_trimFilterDS(int argc, char **argv) {
            par_TF.ad.ad2_fa);
     fprintf(stderr, "   Number of mismatches: %d\n", par_TF.ad.mismatches);
     fprintf(stderr, "   Score threshold: %f\n", par_TF.ad.threshold);
+    if (par_TF.adapter_rm){
+       fprintf(stderr, "   Removing adapter reads\n");
+    }
   }
   // handling minQ
   if (par_TF.minQ == 0) {
@@ -560,7 +563,7 @@ void getarg_trimFilterDS(int argc, char **argv) {
   else {
      fprintf(stderr, "OPTION_ERROR: Invalid --trimN option.\n");
      fprintf(stderr, "              Possible options: NO, ALL, ENDS,");
-     fprintf(stderr, " STRIP.\n");
+     fprintf(stderr, " STRIP, FRAC.\n");
      fprintf(stderr, "              Revise your options with --help.\n");
      fprintf(stderr, "Exiting program\n");
      fprintf(stderr, "File: %s, line: %d\n", __FILE__, __LINE__);

--- a/src/init_trimFilterDS.c
+++ b/src/init_trimFilterDS.c
@@ -73,6 +73,8 @@ void printHelpDialog_trimFilterDS() {
    "               <AD2.fa>: fasta file containing adapters,\n"
    "               <mismatches>: maximum mismatch count allowed,\n"
    "               <score>: score threshold  for the aligner.\n"
+   " -r, --adapter-rm  if the adapter is matched, instead of trimming it\n"
+   "               , the reads are removed."
    " -x, --idx     index input file. To be included with any methods to remove.\n"
    "               contaminations (TREE, BLOOM). 3 fields separated by colons: \n"
    "               <INDEX_FILE>: output of makeTree, makeBloom,\n"
@@ -120,8 +122,11 @@ void printHelpDialog_trimFilterDS() {
    "               ALL:    removes all reads containing N's,\n"
    "               ENDS:   trims ends of reads with N's,\n"
    "               STRIPS: looks for the largest substring with no N's.\n"
+   "               FRAC:   removes the reads if the uncertainty is above a threshold\n"
+   "                       (-u), default to 10 percent\n"
    "               All reads are discarded if they are shorter than the\n"
-   "               sequence length specified by -m/--minL.\n";
+   "               sequence length specified by -m/--minL.\n"
+   " -u, --uncert  percentage of uncertainity tolerated\n";
   fprintf(stderr, "%s", dialog);
 }
 
@@ -130,7 +135,7 @@ void printHelpDialog_trimFilterDS() {
  *        and stores them in the global variable par_TF.
 */
 void getarg_trimFilterDS(int argc, char **argv) {
-  if ( argc != 2 && (argc > 25 || argc % 2 == 0 || argc == 1) ) {
+  if ( argc != 2 && (argc > 25 || argc == 1) ) {
      fprintf(stderr, "Not an adequate number of arguments\n");
      printHelpDialog_trimFilterDS();
      fprintf(stderr, "File: %s, line: %d\n", __FILE__, __LINE__);
@@ -165,12 +170,15 @@ void getarg_trimFilterDS(int argc, char **argv) {
      {"global", required_argument, 0, 'g'},
      {"minL", required_argument, 0, 'm'},
      {"trimN", required_argument, 0, 'N'},
+     {"uncert", required_argument, 0, 'u'},
+     {"adapter-rm", required_argument, 0, 'r'},
   };
   int option;
   int method_len = 20;
   Split globTrim, adapt, tree_fa, index, in_fq;
-  while ((option = getopt_long(argc, argv, "hvf:l:o:z:A:q:x:a:C:Q:m:p:g:N:0:",
+  while ((option = getopt_long(argc, argv, "hvf:l:o:z:A:q:x:a:C:Q:m:p:g:N:0:r:u:",
         long_options, 0)) != -1) {
+    fprintf(stderr,"%c\n",option);
     switch (option) {
       case 'h':
         printHelpDialog_trimFilterDS();
@@ -290,6 +298,12 @@ void getarg_trimFilterDS(int argc, char **argv) {
       case 'p':
          par_TF.percent = atoi(optarg);
          break;
+      case 'u':
+         par_TF.uncertain = atoi(optarg);
+         break;
+      case 'r':
+         par_TF.adapter_rm = true;
+         break;
       case 'g':
          globTrim = strsplit(optarg, ':');
          if (globTrim.N != 2) {
@@ -306,7 +320,8 @@ void getarg_trimFilterDS(int argc, char **argv) {
          par_TF.trimN = (!strncmp(optarg, "NO", method_len)) ? NO :
             (!strncmp(optarg, "ALL", method_len)) ? ALL :
             (!strncmp(optarg, "ENDS", method_len)) ? ENDS :
-            (!strncmp(optarg, "STRIP", method_len)) ? STRIP : ERROR;
+            (!strncmp(optarg, "STRIP", method_len)) ? STRIP : 
+            (!strncmp(optarg, "FRAC", method_len)) ? ENDSFRAC : ERROR;
          break;
       default:
         fprintf(stderr, "%s: option `-%c' is invalid: ignored\n",
@@ -536,7 +551,13 @@ void getarg_trimFilterDS(int argc, char **argv) {
      fprintf(stderr, "- Trimming reads with N's, method: ENDS\n");
   } else if (par_TF.trimN == STRIP) {
      fprintf(stderr, "- Trimming reads with N's, method: STRIP\n");
-  } else {
+  } else if (par_TF.trimN == ENDSFRAC) {
+     fprintf(stderr, "- Removing reads with N's, method: FRAC\n");
+     if (par_TF.uncertain == 0) {
+      par_TF.uncertain = 10;
+    }
+  } 
+  else {
      fprintf(stderr, "OPTION_ERROR: Invalid --trimN option.\n");
      fprintf(stderr, "              Possible options: NO, ALL, ENDS,");
      fprintf(stderr, " STRIP.\n");

--- a/src/trim.c
+++ b/src/trim.c
@@ -62,6 +62,30 @@ static int no_N(Fq_read *seq) {
 }
 
 /**
+*
+* @brief checks if a sequence contains non standard base callings greater than the threshold (N's)
+* @returns 0 if percentage less than threshold, 1 if more.
+*
+* This function checks if any of the base callings in a
+* given fastq read is different from A, C, G, T. Basically,
+* any char different from the former ones is classified as N.
+* */
+static int Nuncertain(Fq_read *seq, int threshold) {
+  int i;
+  char Lmer[seq -> L];
+  memcpy(Lmer, seq -> line2, seq -> L);
+  Lmer_sLmer(Lmer, seq -> L);
+  float ncount=0;
+  for (i = 0; i < seq -> L; i++) {
+    if (Lmer[i] >= Nencode) {
+      ncount++;
+    }
+  }
+  ncount=ncount*100/(float)seq -> L;
+  return (ncount<=threshold);
+}
+
+/**
  * @brief Finds the largest Nfree sub-seq and keeps it if larger than minL
  * @param seq fastq read
  * @param minL minimum accepted trimmed length
@@ -661,12 +685,15 @@ int trim_adapter(Fq_read *seq, Ad_seq *adap_list) {
  * - STRIP(3): finds the longest N-free subsequence and trims it if
  *             it is at least minL nucleotides long (2 if trimming, 1 if
  *             no N's are found), rejects it otherwise (0).
+ *  -ENDSFRAC(4):   removes the reads if the uncertainty is above a threshold\n"
+   "                       (-u), default to 10 percent\n"
  * */
 int trim_sequenceN(Fq_read *seq ) {
   return (par_TF.trimN == NO)? 1:
           (par_TF.trimN == ALL)? no_N(seq):
           (par_TF.trimN == ENDS)? Ntrim_ends(seq, par_TF.minL):
-          (par_TF.trimN == STRIP)? Nfree_Lmer(seq, par_TF.minL): -1;
+          (par_TF.trimN == STRIP)? Nfree_Lmer(seq, par_TF.minL):
+          (par_TF.trimN == ENDSFRAC)? Nuncertain(seq, par_TF.uncertain): -1;
 }
 
 /**

--- a/src/trimDS.c
+++ b/src/trimDS.c
@@ -191,8 +191,12 @@ static int alignDS_uint64(Fq_read *r1, Fq_read *r2, int zeroQ) {
     pos1--;
   }
   if (score > par_TF.ad.threshold) {
-     return ((Lnew = r2->L - r1->L_ad + pos1 - pos2) < par_TF.minL) ?
-             0 : QtrimDS(r1, r2, Lnew);
+    if (par_TF.adapter_rm){
+      return 0;
+    }else{
+      return ((Lnew = r2->L - r1->L_ad + pos1 - pos2) < par_TF.minL) ?
+                  0 : QtrimDS(r1, r2, Lnew);
+    }
   }
   // Controlar bytes al inicio del read
   // loop done on the adapter sequence  without considering the first
@@ -219,8 +223,12 @@ static int alignDS_uint64(Fq_read *r1, Fq_read *r2, int zeroQ) {
     pos2++;
   }
   if (score > par_TF.ad.threshold) {
-      return ( (Lnew = r2->L - r1->L_ad + pos1 - pos2) < par_TF.minL ? 0 :
+     if (par_TF.adapter_rm){
+      return 0;
+     }else{
+        return ( (Lnew = r2->L - r1->L_ad + pos1 - pos2) < par_TF.minL ? 0 :
            QtrimDS(r1, r2, Lnew));
+     }  
   }
   return 1;
 }

--- a/src/trimFilterDS.c
+++ b/src/trimFilterDS.c
@@ -56,6 +56,7 @@ Iparam_trimFilter par_TF;  /**< global variable: Input parameters of makeTree.*/
  *
  * */
 int main(int argc, char *argv[]) {
+
   // Read in command line arguments
   fprintf(stderr, "trimFilterPE from FastqPuri\n");
   getarg_trimFilterDS(argc, argv);


### PR DESCRIPTION
I was trying to use the program to remove some bad quality reads, and I found out I wasn't able to run the option --trimQ FRAC, even tho I should be able to. So I did a quick fix for it.